### PR TITLE
Fix filename decryption issue

### DIFF
--- a/wabdd/commands/decrypt.py
+++ b/wabdd/commands/decrypt.py
@@ -16,9 +16,12 @@ import os
 import pathlib
 import sys
 import zlib
+import re
 from datetime import datetime
 from queue import Queue
 from threading import Event, Thread
+from urllib.parse import unquote
+from typing import Union
 
 import click
 from Cryptodome.Cipher import AES
@@ -126,6 +129,39 @@ def decrypt_metadata(metadata_file: pathlib.Path, key: Key15):
     with open(metadata_file) as f:
         return mcrypt1_metadata_decrypt(key=key, encoded=f.read())
 
+def fix_filename(txt: Union[str, pathlib.Path]) -> str:
+    if txt is None or txt == '':
+        return ''
+
+    decoded = str(txt)
+    if '%' in decoded:
+        decoded = decoded.replace('%2B', '§PLUS§')
+        decoded = unquote(decoded)
+        decoded = decoded.replace('+', ' ')
+        decoded = decoded.replace('§PLUS§', '+')
+
+    if not decoded or set(decoded) <= {' ', '+'}:
+        if all(c == '+' for c in decoded):
+            return decoded.replace('+', '')
+        return ''
+
+    FILLER = '-'
+    EXCLUDED_CHRS = set(r'<>:"/\|?*\0')
+    DEVICE_NAMES = {'CON', 'PRN', 'AUX', 'NUL', 'COM1', 'COM2', 'COM3', 'COM4',
+                    'COM5', 'COM6', 'COM7', 'COM8', 'COM9', 'LPT1', 'LPT2',
+                    'LPT3', 'LPT4', 'LPT5', 'LPT6', 'LPT7', 'LPT8', 'LPT9',
+                    'CONIN$', 'CONOUT$', '..', '.'}
+
+    result = ''.join(x if x not in EXCLUDED_CHRS and (ord(x) >= 32 or ord(x) > 127) else FILLER for x in decoded)
+
+    if result.upper() in DEVICE_NAMES:
+        result = f'-{result}-'
+
+    result = result[:255]
+    result = re.sub(r'^[. ]', FILLER, result)
+    result = re.sub(r'[. ]$', FILLER, result)
+
+    return result if result else ''
 
 def decrypt_mcrypt1_file(
     dump_folder: pathlib.Path, encrypted_file: pathlib.Path, key: Key15
@@ -149,6 +185,7 @@ def decrypt_mcrypt1_file(
     if metadata_file.is_file():
         metadata = decrypt_metadata(metadata_file, key)
         output_file = pathlib.Path(metadata["name"])
+        output_file = fix_filename(output_file)  
 
     with open(encrypted_file, "rb") as f:
         return (
@@ -165,6 +202,7 @@ def decrypt_crypt15_file(
 
     # Remove .crypt15 extension
     output_file = output_file.with_suffix("")
+    output_file = fix_filename(output_file)
 
     # Open .crypt15 file
     with open(encrypted_file, "rb") as f:


### PR DESCRIPTION
Problem Description:
When decrypting URL-encoded filenames with Turkish and other languages characters, the function incorrectly transforms the original filename. Example:

Original Filename: Yeni Klasör 2
Decrypted Filename: Yeni+klas%C3%B6r+%282%29

The issue stems from incomplete Unicode character handling during URL decoding, which can:

Corrupt special characters
Misinterpret Turkish character encodings
Potentially break file naming across different systems

And I solved that problems in that pr.

Also you can run the tests;

```python
import re
import pathlib
from urllib.parse import unquote
from typing import Union

def fix_filename(txt: Union[str, pathlib.Path]) -> str:
    if txt is None or txt == '':
        return ''

    decoded = str(txt)
    if '%' in decoded:
        decoded = decoded.replace('%2B', '§PLUS§')
        decoded = unquote(decoded)
        decoded = decoded.replace('+', ' ')
        decoded = decoded.replace('§PLUS§', '+')

    if not decoded or set(decoded) <= {' ', '+'}:
        if all(c == '+' for c in decoded):
            return decoded.replace('+', '')
        return ''

    FILLER = '-'
    EXCLUDED_CHRS = set(r'<>:"/\|?*\0')
    DEVICE_NAMES = {'CON', 'PRN', 'AUX', 'NUL', 'COM1', 'COM2', 'COM3', 'COM4',
                    'COM5', 'COM6', 'COM7', 'COM8', 'COM9', 'LPT1', 'LPT2',
                    'LPT3', 'LPT4', 'LPT5', 'LPT6', 'LPT7', 'LPT8', 'LPT9',
                    'CONIN$', 'CONOUT$', '..', '.'}

    result = ''.join(x if x not in EXCLUDED_CHRS and (ord(x) >= 32 or ord(x) > 127) else FILLER for x in decoded)

    if result.upper() in DEVICE_NAMES:
        result = f'-{result}-'

    result = result[:255]
    result = re.sub(r'^[. ]', FILLER, result)
    result = re.sub(r'[. ]$', FILLER, result)

    return result if result else ''

def test_filename_fixes():
    test_cases = [
        ("Yeni+klas%C3%B6r+%282%29", "Yeni klasör (2)"),
        ("Dosya%20adı.txt", "Dosya adı.txt"),
        ("Yeni klasör (2)+", "Yeni klasör (2)+"),
        ("Document+.txt", "Document+.txt"),
        ("Hello+World%2B", "Hello World+"),
        ("Test%2B+File", "Test+ File"),
        ("%D0%9F%D1%80%D0%B8%D0%BC%D0%B5%D1%80%2B", "Пример+"),
        ("%E4%BD%A0%E5%A5%BD+%2B+File.txt", "你好 + File.txt"),
        ("%F0%9F%98%80+Smile%2B", "😀 Smile+"),
        ("plain_filename.txt", "plain_filename.txt"),
        ("Hello World+.txt", "Hello World+.txt"),
        ("%2BFile%2B", "+File+"),
        ("No+encoding%21", "No encoding!"),
        ("File%20Name%21%40%23%24.txt", "File Name!@#$.txt"),
        ("%C3%87%C4%B1lg%C4%B1n+Dosya.txt", "Çılgın Dosya.txt"),
    ]

    failed_cases = []
    for encoded, expected in test_cases:
        result = fix_filename(pathlib.Path(encoded))
        if str(result) != expected:
            failed_cases.append({
                'input': encoded,
                'expected': expected,
                'got': result
            })
            print(f"\nTest case:")
            print(f"Input:    {encoded}")
            print(f"Expected: {expected}")
            print(f"Got:      {result}")
            print(f"Pass:     False")

    if failed_cases:
        print("\nFailed Test Cases:")
        for case in failed_cases:
            print(f"Input: {case['input']}")
            print(f"Expected: {case['expected']}")
            print(f"Got: {case['got']}\n")
    else:
        print("All test cases passed successfully!")

test_filename_fixes()
```
